### PR TITLE
MOBILE-562 - Fixed bug where accessibility elements would become stale

### DIFF
--- a/HMSegmentedControl/HMSegmentedControl.m
+++ b/HMSegmentedControl/HMSegmentedControl.m
@@ -177,6 +177,7 @@
 
 - (void)setSectionTitles:(NSArray<NSString *> *)sectionTitles {
     _sectionTitles = sectionTitles;
+    _accessibleElements = nil;
     
     [self setNeedsLayout];
     [self setNeedsDisplay];
@@ -184,6 +185,7 @@
 
 - (void)setSectionImages:(NSArray<UIImage *> *)sectionImages {
     _sectionImages = sectionImages;
+    _accessibleElements = nil;	
     
     [self setNeedsLayout];
     [self setNeedsDisplay];


### PR DESCRIPTION
Accessibility elements weren't being refreshed previously, so updates to the tabs wouldn't register with UITest.